### PR TITLE
Abandon soft dependencies whose target has an unsatisfiable hard dependency

### DIFF
--- a/tests/tests/test_import.py
+++ b/tests/tests/test_import.py
@@ -2022,6 +2022,89 @@ class TestImport(TestCase):
 
         self.assertEqual(run_order, ["C", "B", "A"])
 
+    def test_soft_dependency_on_unsatisfiable_operation_is_abandoned(self):
+        # A softly depends on B (e.g. a rich text/streamfield link); B hard-depends
+        # on C, which can never be resolved (simulating a NO_FOLLOW_MODELS target
+        # that's missing at the destination). B was only ever reachable via A's
+        # soft link, so the top-level satisfiability sweep never discovers that B
+        # is broken. B should be silently dropped rather than crashing, and A
+        # should still be created.
+        run_order = []
+        dependency_model = object()
+        operation_a = FakeOperation("A", [(dependency_model, "B", False)], run_order)
+        operation_b = FakeOperation("B", [(dependency_model, "C", True)], run_order)
+
+        importer = ImportPlanner(model="tests.category", source_site="staging")
+        importer.operations = [operation_a, operation_b]
+        importer.resolutions = {
+            (dependency_model, "A"): operation_a,
+            (dependency_model, "B"): operation_b,
+            # no resolution recorded for C - it was never created
+        }
+        importer.failed_creations = {(dependency_model, "C")}
+
+        importer.run()
+
+        self.assertEqual(run_order, ["A"])
+
+    def test_soft_rich_text_link_to_page_with_unsatisfiable_hard_dependency(self):
+        # Real-world shape this was found in: a page with a rich text link (soft
+        # dependency) to a RedirectPage, whose non-nullable `redirect_to` FK (hard
+        # dependency) points at a page outside the imported subtree that's also
+        # missing at the destination. The rich-text-linking page must still be
+        # importable, with the broken redirect silently dropped, rather than the
+        # whole import raising KeyError/AssertionError.
+        data = """{
+            "ids_for_import": [
+                ["wagtailcore.page", 10],
+                ["wagtailcore.page", 11]
+            ],
+            "mappings": [
+                ["wagtailcore.page", 10, "10101010-0000-0000-0000-000000000000"],
+                ["wagtailcore.page", 11, "11111111-0000-0000-0000-000000000000"],
+                ["wagtailcore.page", 31, "31313131-3131-3131-3131-313131313131"]
+            ],
+            "objects": [
+                {
+                    "model": "tests.pagewithrichtext",
+                    "pk": 10,
+                    "parent_id": 2,
+                    "fields": {
+                        "title": "page with soft link to broken redirect",
+                        "show_in_menus": false,
+                        "live": true,
+                        "slug": "soft-link-to-broken-redirect",
+                        "body": "<p>link to <a id=\\"11\\" linktype=\\"page\\">redirect</a></p>",
+                        "wagtail_admin_comments": []
+                    }
+                },
+                {
+                    "model": "tests.redirectpage",
+                    "pk": 11,
+                    "parent_id": 10,
+                    "fields": {
+                        "title": "redirect to unimported page",
+                        "show_in_menus": false,
+                        "live": true,
+                        "slug": "redirect-to-missing-page",
+                        "redirect_to": 31,
+                        "wagtail_admin_comments": []
+                    }
+                }
+            ]
+        }"""
+
+        importer = ImportPlanner(root_page_source_pk=10, destination_parent_id=2, source_site="staging")
+        importer.add_json(data)
+        # force a deterministic worst-case ordering, as in test_import_with_soft_dependency_on_grandchild
+        importer.operations = list(importer.operations)
+        importer.operations.sort(key=lambda op: op.object_data['fields']['title'])
+
+        importer.run()  # must not raise
+
+        self.assertTrue(PageWithRichText.objects.filter(slug="soft-link-to-broken-redirect").exists())
+        self.assertFalse(RedirectPage.objects.filter(slug="redirect-to-missing-page").exists())
+
     @mock.patch('requests.get')
     def test_import_custom_file_field(self, get):
         get.return_value.status_code = 200

--- a/wagtail_transfer/operations.py
+++ b/wagtail_transfer/operations.py
@@ -474,7 +474,7 @@ class ImportPlanner:
             held_operations = []
             for operation in satisfiable_operations:
                 try:
-                    self._add_to_operation_order(operation, operation_order, [operation])
+                    self._add_to_operation_order(operation, operation_order, [operation], statuses)
                 except CircularDependencyException as e:
                     # if the exception has propagated to this level it ought to be a soft dependency,
                     # as otherwise it should have been caught by _check_satisfiable.
@@ -548,7 +548,7 @@ class ImportPlanner:
         # We've got through all the dependencies without anything failing. Yay!
         return True
 
-    def _add_to_operation_order(self, operation, operation_order, path):
+    def _add_to_operation_order(self, operation, operation_order, path, statuses):
         # path is the sequence of dependencies we've followed so far, starting from the top-level
         # operation picked from satisfiable_operations in `run`, to find one we can add
 
@@ -592,9 +592,18 @@ class ImportPlanner:
                 # unsatisfied.
                 raise CircularDependencyException()
             else:
+                if not dep_is_hard and not self._check_satisfiable(resolution, statuses):
+                    # This dependency's target would need to be created, but it has its own
+                    # unsatisfiable hard dependency that the top-level satisfiability sweep
+                    # never discovered (it was only reachable via this soft link - e.g. a rich
+                    # text or streamfield reference). Since our link to it is soft, we can (and
+                    # must) abandon it rather than trying to order/create it.
+                    logger.debug(f"Abandoning soft dependency on unsatisfiable operation: {dep_model, dep_source_id}")
+                    continue
+
                 try:
                     # recursively add the operation that we're depending on here
-                    self._add_to_operation_order(resolution, operation_order, path + [resolution])
+                    self._add_to_operation_order(resolution, operation_order, path + [resolution], statuses)
                 except CircularDependencyException:
                     if dep_is_hard:
                         # we can't resolve the circular dependency by breaking the chain here,


### PR DESCRIPTION
## Summary

Found while investigating a real crash on Buckinghamshire ([BC-62](https://torchbox.atlassian.net/browse/BC-62)) during a `wagtail-transfer` import: the whole transfer aborted with

```
KeyError: (<class 'wagtail.models.Page'>, 9872)
AssertionError: dependency is hard
```

instead of gracefully skipping the one broken object, as `_check_satisfiable`/`_add_to_operation_order` are designed to do.

This branch builds on `fix/circular-satisfiable-dependencies` (#167), which fixes `CircularDependencyException` propagating uncaught out of `run()`'s top-level ordering loop. That fix doesn't touch this bug — it's a different gap in the same area of `operations.py`.

## Root cause

- `_check_satisfiable()` only recurses through **hard** dependencies (`if not is_hard_dep: continue`). It never checks whether a *soft*-linked target is itself satisfiable.
- `_add_to_operation_order()` walks **every** dependency, hard or soft, and if the target has a real `resolution` (an operation that's genuinely going to be created), it unconditionally recurses into ordering it — regardless of whether the link to it was hard or soft.

So: if page A has a *soft* reference (a rich text or streamfield link, always soft) to page B, and B has its own unsatisfiable *hard* dependency (e.g. a non-nullable FK, or a custom field adapter that forces a nullable FK to be hard), `_check_satisfiable(A)` never notices B is broken — the soft link is skipped, so A is deemed satisfiable. `_add_to_operation_order(A)` then recurses into ordering B anyway, and inside B's own dependency loop hits the real unsatisfiable hard dependency, tripping the `assert not dep_is_hard, "dependency is hard"` that was only ever meant to be unreachable.

The concrete real-world trigger on Buckinghamshire: a page with a streamfield block linking to a `RedirectPage`, whose `internal_page` FK is forced to a hard dependency by a custom field adapter (so a redirect with an unreachable target is dropped rather than published broken) and points at a page outside the imported subtree that's missing at the destination.

## Fix

Before recursing into a *soft* dependency's resolution in `_add_to_operation_order`, verify the target is actually satisfiable (reusing the same memoized `statuses` dict from `_check_satisfiable`, threaded through for efficiency). If it isn't, abandon the dependency exactly like the existing "no resolution found" branch already does, instead of recursing into ordering a doomed operation. Hard-dependency handling is untouched — that path was already correct.

## Tests

- `test_soft_dependency_on_unsatisfiable_operation_is_abandoned` — lightweight `FakeOperation`-based unit test matching the existing `test_retries_held_operations_for_satisfiable_soft_cycle` style.
- `test_soft_rich_text_link_to_page_with_unsatisfiable_hard_dependency` — integration test using real `Page`/`RedirectPage` models and a real rich text link, reproducing the Buckinghamshire shape directly.

Both tests fail with the exact `KeyError`/`AssertionError: dependency is hard` reported above when the fix is reverted, and pass with it applied. Full existing suite (86 tests) passes with no regressions.